### PR TITLE
Makes git_info also work in other language environments

### DIFF
--- a/bash-powerline.sh
+++ b/bash-powerline.sh
@@ -68,17 +68,18 @@ __powerline() {
     __git_info() { 
         [ -x "$(which git)" ] || return    # git not found
 
+        local git_eng="env LANG=C git"   # force git output in English to make our work easier
         # get current branch name or short SHA1 hash for detached head
-        local branch="$(git symbolic-ref --short HEAD 2>/dev/null || git describe --tags --always 2>/dev/null)"
+        local branch="$($git_eng symbolic-ref --short HEAD 2>/dev/null || $git_eng describe --tags --always 2>/dev/null)"
         [ -n "$branch" ] || return  # git branch not found
 
         local marks
 
         # branch is modified?
-        [ -n "$(git status --porcelain)" ] && marks+=" $GIT_BRANCH_CHANGED_SYMBOL"
+        [ -n "$($git_eng status --porcelain)" ] && marks+=" $GIT_BRANCH_CHANGED_SYMBOL"
 
         # how many commits local branch is ahead/behind of remote?
-        local stat="$(git status --porcelain --branch | grep '^##' | grep -o '\[.\+\]$')"
+        local stat="$($git_eng status --porcelain --branch | grep '^##' | grep -o '\[.\+\]$')"
         local aheadN="$(echo $stat | grep -o 'ahead \d\+' | grep -o '\d\+')"
         local behindN="$(echo $stat | grep -o 'behind \d\+' | grep -o '\d\+')"
         [ -n "$aheadN" ] && marks+=" $GIT_NEED_PUSH_SYMBOL$aheadN"

--- a/bash-powerline.sh
+++ b/bash-powerline.sh
@@ -80,8 +80,8 @@ __powerline() {
 
         # how many commits local branch is ahead/behind of remote?
         local stat="$($git_eng status --porcelain --branch | grep '^##' | grep -o '\[.\+\]$')"
-        local aheadN="$(echo $stat | grep -o 'ahead \d\+' | grep -o '\d\+')"
-        local behindN="$(echo $stat | grep -o 'behind \d\+' | grep -o '\d\+')"
+        local aheadN="$(echo $stat | grep -o 'ahead [[:digit:]]\+' | grep -o '[[:digit:]]\+')"
+        local behindN="$(echo $stat | grep -o 'behind [[:digit:]]\+' | grep -o '[[:digit:]]\+')"
         [ -n "$aheadN" ] && marks+=" $GIT_NEED_PUSH_SYMBOL$aheadN"
         [ -n "$behindN" ] && marks+=" $GIT_NEED_PULL_SYMBOL$behindN"
 


### PR DESCRIPTION
Before, the git output varies depending on user's locale, which makes `__git_info` broken in language other than English. I added `env LANG=C` in front of all git callings to fix it.

Furthermore, originally there are `\d`s in grep regex, which is not standard and unportable. I changed them to POSIX `[:digit:]`.