### PR TITLE
Updated README.md to use raw.githubusercontent.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Powerline for Bash in pure Bash script.
 
 Download the Bash script
 
-    curl https://raw.github.com/riobard/bash-powerline/master/bash-powerline.sh > ~/.bash-powerline.sh
+    curl https://raw.githubusercontent.com/riobard/bash-powerline/master/bash-powerline.sh > ~/.bash-powerline.sh
 
 And source it in your `.bashrc`
 


### PR DESCRIPTION
I had an issue with curl using old URL. After looking at redirect at browser - `raw.github.com -> raw.githubusercontent.com` - I tried new URL with curl and it worked.
Related GitHub article: https://developer.github.com/changes/2014-04-25-user-content-security/