### PR TITLE
Support Python virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Powerline for Bash in pure Bash script.
 * Git branch: display "+" symbol when current branch is changed but uncommited
 * Git branch: display "⇡" symbol and the difference in the number of commits when the current branch is ahead of remote (see screenshot)
 * Git branch: display "⇣" symbol and the difference in the number of commits when the current branch is behind of remote (see screenshot)
+* Python virtualenv: display current virtual environment
 * Platform-dependent prompt symbol for OS X and Linux (see screenshots)
 * Color code for the previously failed command
 * Fast execution (no noticable delay)

--- a/bash-powerline.sh
+++ b/bash-powerline.sh
@@ -89,6 +89,21 @@ __powerline() {
         printf " $GIT_BRANCH_SYMBOL$branch$marks "
     }
 
+    __virtualenv() {
+        # Copied from Python virtualenv's activate.sh script.
+        # https://github.com/pypa/virtualenv/blob/a9b4e673559a5beb24bac1a8fb81446dd84ec6ed/virtualenv_embedded/activate.sh#L62
+        # License: MIT
+        if [ "x$VIRTUAL_ENV" != "x" ]; then
+            if [ "`basename \"$VIRTUAL_ENV\"`" == "__" ]; then
+                # special case for Aspen magic directories
+                # see http://www.zetadev.com/software/aspen/
+                printf "[`basename \`dirname \"$VIRTUAL_ENV\"\``]"
+            else
+                printf "(`basename \"$VIRTUAL_ENV\"`)"
+            fi
+        fi
+    }
+
     ps1() {
         # Check the exit code of the previous command and display different
         # colors in the prompt accordingly. 
@@ -98,7 +113,9 @@ __powerline() {
             local BG_EXIT="$BG_RED"
         fi
 
-        PS1="$BG_BASE1$FG_BASE3 \w $RESET"
+        PS1=""
+        PS1+="$BG_BASE0$FG_BASE3$(__virtualenv)$RESET"
+        PS1+="$BG_BASE1$FG_BASE3 \w $RESET"
         PS1+="$BG_BLUE$FG_BASE3$(__git_info)$RESET"
         PS1+="$BG_EXIT$FG_BASE3 $PS_SYMBOL $RESET "
     }


### PR DESCRIPTION
When bash-powerline is used, the PS1 magic in virtualenv's `activate.sh` script no longer works. This PR adds the support to display the name of current virtualenv, similar to what `activate.sh` does without bash-powerline. It has no effects when virtualenv is not activated. And the code is structured in a way that people can easily comment it out if they don't want this feature (although I doubt there's any reason doing so).

Screenshot (".env" is the name of my virtualenv): ![bash-powerline-virtualenv](https://i.imgur.com/vgOYTma.png)