### PR TITLE
Add .profile on README for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Download the Bash script
 
     curl https://raw.githubusercontent.com/riobard/bash-powerline/master/bash-powerline.sh > ~/.bash-powerline.sh
 
-And source it in your `.bashrc`
+And source it in your `.bashrc` (or `.profile` on Mac):
 
     source ~/.bash-powerline.sh
 


### PR DESCRIPTION
On MacOS the right file to include the `source ~/.bash-powerline.sh` should be `.profile` not `.bashrc`, so i included a hint for those users.
