### PR TITLE
Reduce the number of external tools and need to execute external executables

### DIFF
--- a/bash-powerline.sh
+++ b/bash-powerline.sh
@@ -105,7 +105,8 @@ __powerline() {
     fi
 
     __git_info() { 
-        [ -x "$(which git)" ] || return    # git not found
+        # is git found in PATH
+        hash git 2>/dev/null || return
 
         local git_eng="env LANG=C git"   # force git output in English to make our work easier
         # get current branch name or short SHA1 hash for detached head

--- a/bash-powerline.sh
+++ b/bash-powerline.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 __powerline() {
+    if ! hash tput 2>/dev/null; then
+        >&2 echo "tput missing, install ncurses to use bash-powerline.sh"
+        return
+    fi
 
     # Unicode symbols
     readonly PS_SYMBOL_DARWIN=''


### PR DESCRIPTION
Removes the need to external tools:
- `which` - replaced with built-in `hash`
- `grep` - replaced with bash regexes

Git is executed only once instead of thrice.

Speeds up execution in Windows MSYS2 quite noticeably.

Average `ps1` speeds in repository with thousands of files and ~20 submodules:

  orig: 1464 ms, this: 767 ms
  orig: 1407 ms, this: 642 ms
  orig: 1397 ms, this: 439 ms

Speedup on Linux or Mac OS X isn't that dramatic, but occasionally I'm stuck with Windows and MSYS2.